### PR TITLE
Fix TypeScript typing for `recursive`

### DIFF
--- a/src/camelize.ts
+++ b/src/camelize.ts
@@ -11,7 +11,7 @@ const converters: { [style in CaseEnum]: (string?: string) => string } = {
   snakeCase,
 }
 
-export type Recursive = true | { excludes: string[] };
+export type Recursive = boolean | { excludes: string[] };
 export type Excludes = string[] | RegExp | ((key: string) => boolean);
 export interface Exception { [key: string]: string | ((key?: string) => string); }
 


### PR DESCRIPTION
If my recursivity is conditonal (like `recursive: isAdmin`, `isAdmin` being a `boolean` that can be `true` or `false`), TypeScript complains because with the current typings, it can only be `true`.